### PR TITLE
update to handystats v2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,11 +24,12 @@ Build-Depends: debhelper (>=5),
  libcrypto++-dev,
  libyandex-utils-http,
  libcurl4-openssl-dev,
- handystats (>= 1.10.2),
+ libhandystats2,
+ libhandystats-dev,
 Standards-Version: 3.9.1
 
 Package: mediastorage-proxy
 Architecture: any
-Depends: ${shlibs:Depends}, libthevoid2 (>= 0.7.0.3), libthevoid2 (<< 0.8), libswarm2 (>= 0.7.0.3), libswarm2 (<< 0.8), libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, elliptics-client(>= 2.26.3.31), handystats (>= 1.10.2),
+Depends: ${shlibs:Depends}, libthevoid2 (>= 0.7.0.3), libthevoid2 (<< 0.8), libswarm2 (>= 0.7.0.3), libswarm2 (<< 0.8), libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, elliptics-client(>= 2.26.3.31), libhandystats2,
 Description: Proxy with elliptics support based on thevoid
 

--- a/example/config_stats.json
+++ b/example/config_stats.json
@@ -46,31 +46,31 @@
 			],
 			"group-info-update-period" : 10
 		},
+		"stats-log": {
+			"path": "/tmp/log/mediastorage/stats.log",
+			"period": 1000
+		},
 		"handystats": {
-			"core": {
-				"enable": true
-			},
-			"metrics-dump": {
-				"interval": 500
-			},
-			"statistics": {
+			"enable": true,
+			"dump-interval": 750,
+			"defaults": {
 				"histogram-bins": 30,
 				"moving-interval": 60000,
-				"tags": []
+				"stats": []
 			},
-			"metrics": {
-				"gauge": {
-				},
-				"counter": {
-					"tags": ["rate"],
-					"rate-unit": "s"
-				},
-				"timer": {
-					"idle-timeout": 30000,
-					"tags": ["moving-avg", "quantile"]
-				}
+			"mds.{get,upload}": {
+				"moving-interval": 5000,
+				"stats": ["throughput"]
+			},
+			"mds.{get,upload}.[23]xx.time": {
+				"moving-interval": 5000,
+				"stats": ["moving-avg", "quantile"]
+			},
+			"mds.{get,upload}.[0-9]{xx,[0-9][0-9]}": {
+				"moving-interval": 5000,
+				"stats": ["throughput"]
 			}
-		}
+		},
 		"die-limit" : 1,
 		"eblob-style-path" : true,
 		"direction-bit-num" : 16,

--- a/src/get.hpp
+++ b/src/get.hpp
@@ -20,6 +20,8 @@
 #ifndef SRC__GET__HPP
 #define SRC__GET__HPP
 
+#include "handystats.hpp"
+
 #include "proxy.hpp"
 
 #include "ranges.hpp"
@@ -36,11 +38,14 @@ namespace elliptics {
 class get_helper_t;
 
 struct req_get
-	: public ioremap::thevoid::simple_request_stream<proxy>
+	: public request_wrapper<ioremap::thevoid::simple_request_stream<proxy>>
 	, public std::enable_shared_from_this<req_get>
 {
 	void on_request(const ioremap::thevoid::http_request &req, const boost::asio::const_buffer &buffer);
 	void on_lookup(const ioremap::elliptics::sync_lookup_result &slr, const ioremap::elliptics::error_info &error);
+
+	~req_get();
+
 private:
 	typedef std::function<void (void)> callback_t;
 

--- a/src/handystats.hpp
+++ b/src/handystats.hpp
@@ -43,6 +43,11 @@ struct base_request_wrapper
 		m_received_bytes = 0;
 	}
 
+	virtual
+	~base_request_wrapper()
+	{
+	}
+
 	handystats::chrono::time_point m_start_timestamp;
 
 	size_t m_sent_bytes;

--- a/src/handystats.hpp
+++ b/src/handystats.hpp
@@ -61,7 +61,7 @@ struct request_wrapper
 {
 	template <typename... Args>
 	request_wrapper(Args&& ...args)
-		: RequestStream(args...)
+		: RequestStream(std::forward<Args>(args)...)
 	{
 	}
 

--- a/src/proxy.hpp
+++ b/src/proxy.hpp
@@ -224,6 +224,9 @@ public:
 
 	void cache_update_callback(bool cache_is_expired_);
 
+	void initialize_handystats(const rapidjson::Value &config);
+	void initialize_stats_log(const rapidjson::Value &config);
+
 private:
 public:
 	std::mutex elliptics_mutex;

--- a/src/proxy.hpp
+++ b/src/proxy.hpp
@@ -26,6 +26,8 @@
 #include "utils.hpp"
 #include "cdn_cache.hpp"
 
+#include <handystats/experimental/backends/file_logger.hpp>
+
 #include <elliptics/session.hpp>
 #include <libmastermind/mastermind.hpp>
 #include <thevoid/server.hpp>
@@ -265,6 +267,8 @@ public:
 
 		std::set<std::string> handlers;
 	} header_protector;
+
+	std::unique_ptr<handystats::backends::file_logger> m_stats_logger;
 };
 
 template <typename T>

--- a/src/upload.hpp
+++ b/src/upload.hpp
@@ -20,6 +20,8 @@
 #ifndef MDS_PROXY__SRC__UPLOAD__HPP
 #define MDS_PROXY__SRC__UPLOAD__HPP
 
+#include "handystats.hpp"
+
 #include "utils.hpp"
 #include "proxy.hpp"
 #include "loggers.hpp"
@@ -33,10 +35,12 @@
 namespace elliptics {
 
 class upload_t
-	: public ioremap::thevoid::request_stream<proxy>
+	: public request_wrapper<ioremap::thevoid::request_stream<proxy>>
 	, public std::enable_shared_from_this<upload_t>
 {
 public:
+	~upload_t();
+
 	void
 	on_headers(ioremap::thevoid::http_request &&http_request);
 

--- a/src/upload_p.hpp
+++ b/src/upload_p.hpp
@@ -151,7 +151,7 @@ public:
 };
 
 struct upload_simple_t
-	: public ioremap::thevoid::buffered_request_stream<proxy>
+	: public request_wrapper<ioremap::thevoid::buffered_request_stream<proxy>>
 	, public std::enable_shared_from_this<upload_simple_t>
 {
 	upload_simple_t(namespace_ptr_t ns_, couple_t couple_, std::string filename_);
@@ -191,7 +191,7 @@ private:
 };
 
 struct upload_multipart_t
-	: public ioremap::thevoid::request_stream<proxy>
+	: public request_wrapper<ioremap::thevoid::request_stream<proxy>>
 	, public std::enable_shared_from_this<upload_multipart_t>
 {
 	upload_multipart_t(namespace_ptr_t ns_, couple_t couple_);


### PR DESCRIPTION
**DO NOT MERGE**

Request metrics collection mechanics is performed via request_wrapper.
Upload request instrumented.
Handystats' file_logger added ("stats-log" config section).

Collected metrics:

* mds.\<request\>
  -- rate for request (get, upload)

* mds.\<request\>.\<response code | group\>
  -- rate for response code (101, 200, 404, etc.) or group (1xx, 2xx, 3xx, 4xx, 5xx) of request (get, upload)

* mds.\<request\>.\<2xx | 3xx\>.time
  -- timings for response code group (2xx, 3xx) of request (get, upload)
  -- 'frequency' statistic may be used for rps