### PR TITLE
Hotfix/mds 747

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+mediastorage-proxy (0.82.5) lucid; urgency=low
+
+  * MDS-747: Obtaining results of writings was reorganized
+  * MDS-747: Results will be obtained when async writes are finished
+  * MDS-747: writers state machines release mutex before process callbacks
+  * MDS-747: uploader must release all buffered_writers
+
+ -- Artem Sokolov <derikon@yandex-team.ru>  Wed, 25 Feb 2015 14:36:06 +0400
+
 mediastorage-proxy (0.82.4) lucid; urgency=low
 
   * MDS-747: second attempt

--- a/src/buffered_writer.hpp
+++ b/src/buffered_writer.hpp
@@ -98,7 +98,7 @@ private:
 	};
 
 	typedef std::recursive_mutex mutex_t;
-	typedef std::lock_guard<mutex_t> lock_guard_t;
+	typedef std::unique_lock<mutex_t> lock_guard_t;
 	typedef std::vector<char> buffer_t;
 
 	ioremap::swarm::logger &

--- a/src/buffered_writer.hpp
+++ b/src/buffered_writer.hpp
@@ -84,6 +84,9 @@ public:
 	const writer_ptr_t &
 	get_writer() const;
 
+	const writer_t::result_t &
+	get_result() const;
+
 private:
 	enum class state_tag {
 		  appending
@@ -129,6 +132,7 @@ private:
 	size_t total_size;
 
 	writer_ptr_t writer;
+	writer_t::result_t result;
 };
 
 } // namespace elliptics

--- a/src/upload_multipart.cpp
+++ b/src/upload_multipart.cpp
@@ -150,6 +150,7 @@ upload_multipart_t::on_data(const boost::asio::const_buffer &buffer) {
 
 		// If multipart_context.state is equal to end, the join was already called in this task.
 		if (is_error() && multipart_state_tag::end != multipart_context.state) {
+			buffered_writer.reset();
 			join_upload_tasks();
 			return 0;
 		}

--- a/src/upload_p.hpp
+++ b/src/upload_p.hpp
@@ -159,14 +159,6 @@ private:
 		, client
 	};
 
-	struct part_result_t {
-		std::string name;
-		std::string key_id;
-		std::string key_remote;
-		size_t total_size;
-		writer_t::entries_info_t entries_info;
-	};
-
 	void sm_init();
 	void sm_headers();
 	void sm_body();
@@ -235,7 +227,7 @@ private:
 
 	std::mutex buffered_writers_mutex;
 	std::map<std::string, std::shared_ptr<buffered_writer_t>> buffered_writers;
-	std::vector<part_result_t> results;
+	std::map<std::string, writer_t::result_t> results;
 
 };
 

--- a/src/upload_simple.cpp
+++ b/src/upload_simple.cpp
@@ -136,13 +136,15 @@ upload_simple_t::on_write_is_done(const std::error_code &error_code) {
 
 void
 upload_simple_t::send_result() {
+	const auto &result = writer->get_result();
+
 	std::ostringstream oss;
 	oss 
 		<< "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-		<< "<post obj=\"" << encode_for_xml(writer->get_key())
-		<< "\" id=\"" << writer->get_id()
+		<< "<post obj=\"" << encode_for_xml(result.key)
+		<< "\" id=\"" << result.id
 		<< "\" groups=\"" << ns_state.settings().groups_count()
-		<< "\" size=\"" << writer->get_total_size()
+		<< "\" size=\"" << result.total_size
 		<< "\" key=\"";
 
 	if (proxy_settings(ns_state).static_couple.empty()) {
@@ -151,9 +153,9 @@ upload_simple_t::send_result() {
 
 	oss << encode_for_xml(filename) << "\">\n";
 
-	const auto &result = writer->get_result();
+	const auto &entries_info = result.entries_info;
 
-	for (auto it = result.begin(), end = result.end(); it != end; ++it) {
+	for (auto it = entries_info.begin(), end = entries_info.end(); it != end; ++it) {
 		oss
 			<< "<complete"
 			<< " addr=\"" << it->address << "\""
@@ -163,7 +165,7 @@ upload_simple_t::send_result() {
 	}
 
 	oss
-		<< "<written>" << result.size() << "</written>\n"
+		<< "<written>" << entries_info.size() << "</written>\n"
 		<< "</post>";
 
 	auto res_str = oss.str();

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -166,8 +166,20 @@ elliptics::writer_t::write(const ioremap::elliptics::data_pointer &data_pointer)
 	}
 }
 
-const elliptics::writer_t::entries_info_t &
+elliptics::writer_t::result_t
 elliptics::writer_t::get_result() const {
+	result_t result;
+
+	result.id = get_id();
+	result.key = get_key();
+	result.total_size = get_total_size();
+	result.entries_info = get_entries_info();
+
+	return result;
+}
+
+const elliptics::writer_t::entries_info_t &
+elliptics::writer_t::get_entries_info() const {
 	lock_guard_t lock_guard(state_mutex);
 	(void) lock_guard;
 

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -394,7 +394,6 @@ elliptics::writer_t::on_data_wrote(
 	} while (0)
 
 	lock_guard_t lock_guard(state_mutex);
-	(void) lock_guard;
 
 	switch (state) {
 	case state_tag::writing:
@@ -410,6 +409,7 @@ elliptics::writer_t::on_data_wrote(
 				state = state_tag::waiting;
 			}
 
+			lock_guard.unlock();
 			on_complete(make_error_code(writer_errc::success));
 			return;
 		}
@@ -458,12 +458,12 @@ elliptics::writer_t::on_data_removed(
 		const ioremap::elliptics::sync_remove_result &entries
 		, const ioremap::elliptics::error_info &error_info) {
 	lock_guard_t lock_guard(state_mutex);
-	(void) lock_guard;
 
 	switch (state) {
 	case state_tag::removing: {
 		MDS_LOG_INFO("remove is finished");
 		state = state_tag::failed;
+		lock_guard.unlock();
 		on_complete(make_error_code(errc_for_client));
 		break;
 	}

--- a/src/writer.hpp
+++ b/src/writer.hpp
@@ -67,6 +67,13 @@ public:
 
 	typedef std::vector<entry_info_t> entries_info_t;
 
+	struct result_t {
+		std::string id;
+		std::string key;
+		size_t total_size;
+		entries_info_t entries_info;
+	};
+
 	writer_t(ioremap::swarm::logger bh_logger_
 			, const ioremap::elliptics::session &session_, std::string key_
 			, size_t total_size_, size_t offset_, size_t commit_coef_, size_t success_copies_num_
@@ -79,8 +86,11 @@ public:
 	void
 	write(const ioremap::elliptics::data_pointer &data_pointer);
 
-	const entries_info_t &
+	result_t
 	get_result() const;
+
+	const entries_info_t &
+	get_entries_info() const;
 
 	bool
 	is_finished() const;

--- a/src/writer.hpp
+++ b/src/writer.hpp
@@ -122,7 +122,7 @@ private:
 	};
 
 	typedef std::recursive_mutex mutex_t;
-	typedef std::lock_guard<mutex_t> lock_guard_t;
+	typedef std::unique_lock<mutex_t> lock_guard_t;
 
 	ioremap::swarm::logger &
 	logger();


### PR DESCRIPTION
Deadlock could occur in following case:
First async write is failed and handler interrupts all async writes (i.e. thread locks dict's mutex, and calls interrupt method for every buffered_writer).
In this moment second async write is failed. Handler tries to lock dict's mutex to obtain result, but the mutex is locked by interrupting thread. Interrupting thread tries to set interrup flag for each buffered_writer, but cant because state mutex of one buffered_writer is locked during thread waits dict's mutex to obtain result.

To avoid this condition, results will be obtained when all async writes are finished.
Now the whole write process looks almost linear:
1. One inserts buffered_writer into dict with locked mutex.
2. One starts async write according to the buffered_writer.
3. One checks writing status
 a. If an error occurs, one will call once-method*, that interrupts every async writing with locked mutex.
 b. One increments count of finished writes.
4. One waits finishings of all async writes.
5. One obtains results and clears dict.

* once-method is the method that is run only once independently of number of calls.