### PR TITLE
update to 1.11 handystats

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,12 +24,12 @@ Build-Depends: debhelper (>=5),
  libcrypto++-dev,
  libyandex-utils-http,
  libcurl4-openssl-dev,
- handystats (>= 1.10.2),
+ handystats (>= 1.11.1),
  libssl-dev,
 Standards-Version: 3.9.1
 
 Package: mediastorage-proxy
 Architecture: any
-Depends: ${shlibs:Depends}, libthevoid2 (>= 0.7.0.3), libthevoid2 (<< 0.8), libswarm2 (>= 0.7.0.3), libswarm2 (<< 0.8), libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, elliptics-client(>= 2.26.3.31), handystats (>= 1.10.2), ubic,
+Depends: ${shlibs:Depends}, libthevoid2 (>= 0.7.0.3), libthevoid2 (<< 0.8), libswarm2 (>= 0.7.0.3), libswarm2 (<< 0.8), libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, elliptics-client(>= 2.26.3.31), handystats (>= 1.11.1), ubic,
 Description: Proxy with elliptics support based on thevoid
 

--- a/src/handystats.hpp
+++ b/src/handystats.hpp
@@ -24,14 +24,6 @@
 #include <string>
 
 #include <handystats/measuring_points.hpp>
-#include <handystats/module.h>
-
-#ifndef _HAVE_HANDY_MODULE_MDS
-	#define _HAVE_HANDY_MODULE_MDS 1
-#endif
-
-HANDY_MODULE(MDS)
-
 
 // mds.REQUEST (counter)
 //    - total number of requests
@@ -52,54 +44,36 @@ namespace elliptics {
 // REQUEST
 
 inline void MDS_REQUEST_START(const std::string& method, const uint64_t& instance_id) {
-	char metric_name[256];
+	HANDY_COUNTER_INCREMENT(("mds.%s", method.c_str()));
 
-	sprintf(metric_name, "mds.%s", method.c_str());
-	MDS_COUNTER_INCREMENT(metric_name);
+	HANDY_TIMER_START(("mds.%s.time", method.c_str()), instance_id);
 
-	sprintf(metric_name, "mds.%s.time", method.c_str());
-	MDS_TIMER_START(metric_name, instance_id);
-
-	sprintf(metric_name, "mds.%s.reply.time", method.c_str());
-	MDS_TIMER_START(metric_name, instance_id);
+	HANDY_TIMER_START(("mds.%s.reply.time", method.c_str()), instance_id);
 }
 
 inline void MDS_REQUEST_STOP(const std::string& method, const uint64_t& instance_id) {
-	char metric_name[256];
-
-	sprintf(metric_name, "mds.%s.time", method.c_str());
-	MDS_TIMER_STOP(metric_name, instance_id);
+	HANDY_TIMER_STOP(("mds.%s.time", method.c_str()), instance_id);
 }
 
 inline void MDS_REQUEST_DISCARD(const std::string& method, const uint64_t& instance_id) {
-	char metric_name[256];
-
-	sprintf(metric_name, "mds.%s.time", method.c_str());
-	MDS_TIMER_DISCARD(metric_name, instance_id);
+	HANDY_TIMER_DISCARD(("mds.%s.time", method.c_str()), instance_id);
 }
 
 
 // REPLY
 
 inline void MDS_REQUEST_REPLY(const std::string& method, const int& code, const uint64_t& instance_id) {
-	char metric_name[256];
+	HANDY_COUNTER_INCREMENT(("mds.%s.reply.%d", method.c_str(), code));
 
-	sprintf(metric_name, "mds.%s.reply.%d", method.c_str(), code);
-	MDS_COUNTER_INCREMENT(metric_name);
-
-	sprintf(metric_name, "mds.%s.reply.%dxx", method.c_str(), code / 100);
-	MDS_COUNTER_INCREMENT(metric_name);
+	HANDY_COUNTER_INCREMENT(("mds.%s.reply.%dxx", method.c_str(), code / 100));
 
 	if (code / 100 != 2) {
-		sprintf(metric_name, "mds.%s.time", method.c_str());
-		MDS_TIMER_DISCARD(metric_name, instance_id);
+		HANDY_TIMER_DISCARD(("mds.%s.time", method.c_str()), instance_id);
 
-		sprintf(metric_name, "mds.%s.reply.time", method.c_str());
-		MDS_TIMER_DISCARD(metric_name, instance_id);
+		HANDY_TIMER_DISCARD(("mds.%s.reply.time", method.c_str()), instance_id);
 	}
 	else {
-		sprintf(metric_name, "mds.%s.reply.time", method.c_str());
-		MDS_TIMER_STOP(metric_name, instance_id);
+		HANDY_TIMER_STOP(("mds.%s.reply.time", method.c_str()), instance_id);
 	}
 }
 


### PR DESCRIPTION
HANDY_MODULE() functionality has been removed in 1.11, due to inability to support printf-like syntax.