### PR TITLE
MDS-852: Option expiration-time was added for get handler

### DIFF
--- a/src/get.hpp
+++ b/src/get.hpp
@@ -172,6 +172,8 @@ private:
 	bool has_internal_storage_error;
 
 	std::vector<int> bad_groups;
+
+	boost::optional<std::chrono::seconds> expiration_time;
 };
 
 } // namespace elliptics


### PR DESCRIPTION
Handler get has option expiration-time to customise
expiration time of signature. The option can be used only if
namespace's option custom-expiration-time is set.