### PR TITLE
Update to thevoid 0.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Artem Sokolov <derikon@yandex-team.ru>
 Build-Depends: debhelper (>=5),
  cmake (>= 2.6),
  cdbs,
- libthevoid2 (>= 0.7.2.0), libthevoid2 (<< 0.8),
- libthevoid-dev (>= 0.7.2.0), libthevoid-dev (<< 0.8),
+ libthevoid2 (>= 0.8), libthevoid2 (<< 0.9),
+ libthevoid-dev (>= 0.8), libthevoid-dev (<< 0.9),
  libmastermind-dev (>= 8.26),
  elliptics-dev (>= 2.26.3.33-6), elliptics-dev (<< 2.26.3.34),
  cocaine-framework-native (>= 0.11), cocaine-framework-native (<< 0.12),
@@ -14,8 +14,8 @@ Build-Depends: debhelper (>=5),
  libcocaine-core2 (>= 0.11), libcocaine-core2 (<< 0.12),
  libcocaine-dev (>= 0.11), libcocaine-dev (<< 0.12),
  libboost-system-dev,
- libswarm2 (>= 0.7.2.0), libswarm2 (<< 0.8),
- libswarm-dev (>= 0.7.2.0), libswarm-dev (<< 0.8),
+ libswarm2 (>= 0.8), libswarm2 (<< 0.9),
+ libswarm-dev (>= 0.8), libswarm-dev (<< 0.9),
  libboost-dev,
  libmsgpack-dev,
  libglib2.0-0,
@@ -30,6 +30,6 @@ Standards-Version: 3.9.1
 
 Package: mediastorage-proxy
 Architecture: any
-Depends: ${shlibs:Depends}, libthevoid2 (>= 0.7.0.3), libthevoid2 (<< 0.8), libswarm2 (>= 0.7.0.3), libswarm2 (<< 0.8), libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, elliptics-client(>= 2.26.3.33-6), elliptics-client(<< 2.26.3.34), handystats (>= 1.10.2), handystats (<< 1.11), ubic,
+Depends: ${shlibs:Depends}, libthevoid2 (>= 0.8), libthevoid2 (<< 0.9), libswarm2 (>= 0.8), libswarm2 (<< 0.9), libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, elliptics-client(>= 2.26.3.33-6), elliptics-client(<< 2.26.3.34), handystats (>= 1.10.2), handystats (<< 1.11), ubic,
 Description: Proxy with elliptics support based on thevoid
 

--- a/src/upload_simple.cpp
+++ b/src/upload_simple.cpp
@@ -55,6 +55,9 @@ upload_simple_t::on_request(const ioremap::thevoid::http_request &http_request) 
 			, on_complete, server()->limit_of_middle_chunk_attempts
 			, server()->scale_retry_timeout
 			);
+
+	// It's required to call try_next_chunk() method to receive first chunk of data
+	try_next_chunk();
 }
 
 void


### PR DESCRIPTION
There'll be swarm/thevoid of version 0.8.0.0 shortly.

Major changes of the new version are:
- base_request_stream::get_reply() deprecated method removed (one should use base_request_stream::reply() method instead)
- reply_stream::pause_receive() method added to stop receiving data from client
- first buffered_request_stream::on_chunk() call is postponed until buffered_request_stream::try_next_chunk() method's call

reply_stream::pause_receive() method should be used with caution.
This method is allowed to be called only from within on_headers() and on_data() methods of base_request_stream/request_stream handlers.
It's prohibited to call this method from within on_request() and on_chunk() methods of buffered_request_stream as it's used internally (there's already try_next_chunk() method to control this handler's incoming data).

To resume receiving data from client reply_stream::want_more() must be called after reply_stream::pause_receive().

base_request_stream::on_close() method's call can be postponed with reply_stream::pause_receive() too, but if error happens on_close() with error will be called (**ATTENTION!!!**).