### PR TITLE
MDS-993: Couple retry was fixed

### DIFF
--- a/src/upload_simple.cpp
+++ b/src/upload_simple.cpp
@@ -64,11 +64,15 @@ upload_simple_t::on_chunk(const boost::asio::const_buffer &buffer, unsigned int 
 	const char *buffer_data = boost::asio::buffer_cast<const char *>(buffer);
 	const size_t buffer_size = boost::asio::buffer_size(buffer);
 
-	auto chunk = ioremap::elliptics::data_pointer::from_raw(
-		reinterpret_cast<void *>(const_cast<char *>(buffer_data)), buffer_size);
+	ioremap::elliptics::data_pointer chunk;
 
 	if (can_retry_couple) {
+		chunk = ioremap::elliptics::data_pointer::copy(
+			reinterpret_cast<const void *>(buffer_data), buffer_size);
 		data_pointer = chunk;
+	} else {
+		chunk = ioremap::elliptics::data_pointer::from_raw(
+			reinterpret_cast<void *>(const_cast<char *>(buffer_data)), buffer_size);
 	}
 
 	process_chunk(std::move(chunk));


### PR DESCRIPTION
First chunk is copied to be possible used for couple retries.

Reviewers: @shindo 