### PR TITLE
MDS-958: Response will be 507 if -ENOSPC was occured

### DIFF
--- a/src/upload_simple.hpp
+++ b/src/upload_simple.hpp
@@ -71,6 +71,12 @@ struct upload_simple_t
 	remove(const util::expected<void>::callback_t next);
 
 private:
+	enum class internal_error_errc {
+		  none
+		, general_error
+		, insufficient_storage
+	};
+
 	void
 	get_next_couple_info(util::expected<mastermind::couple_info_t>::callback_t next);
 
@@ -85,6 +91,15 @@ private:
 
 	std::shared_ptr<writer_t>
 	make_writer(const groups_t &groups);
+
+	void
+	update_internal_error(internal_error_errc errc);
+
+	void
+	send_error();
+
+	void
+	send_error(internal_error_errc errc);
 
 	mastermind::namespace_state_t ns_state;
 	couple_iterator_t couple_iterator;
@@ -103,8 +118,9 @@ private:
 	mastermind::couple_info_t couple_info;
 	bool can_retry_couple;
 
-	bool has_internal_error;
 	size_t attempt_to_choose_a_couple;
+
+	internal_error_errc internal_error;
 };
 
 } // namespace elliptics


### PR DESCRIPTION
Enum class with error codes is used instead of boolean variable to make it easier to check errors' states.
Error code is updated according to error conditions and is used to chose 5xx response code.

Error code's updating is following these rules: `none` has the lowest priority and can be replaced with any other, `insufficient_storage` has the highest priority and cannot be replaced with any other.

Reviewers: @shindo 