### PR TITLE
Writer and buffered writer takes callbacks in action methods

### DIFF
--- a/src/buffered_writer.cpp
+++ b/src/buffered_writer.cpp
@@ -67,12 +67,11 @@ elliptics::buffered_writer_error::buffered_writer_error(buffered_writer_errc e
 }
 
 elliptics::buffered_writer_t::buffered_writer_t(ioremap::swarm::logger bh_logger_,
-		std::string key_, size_t chunk_size_ , callback_t on_finished_)
+		std::string key_, size_t chunk_size_)
 	: state(state_tag::appending)
 	, bh_logger(std::move(bh_logger_))
 	, key(std::move(key_))
 	, chunk_size(chunk_size_)
-	, on_finished(std::move(on_finished_))
 	, total_size(0)
 {
 }
@@ -98,21 +97,21 @@ elliptics::buffered_writer_t::append(const char *data, size_t size) {
 void
 elliptics::buffered_writer_t::write(const ioremap::elliptics::session &session, size_t commit_coef
 		, size_t success_copies_num, size_t limit_of_middle_chunk_attempts
-		, double scale_retry_timeout) {
+		, double scale_retry_timeout, callback_t next) {
 	lock_guard_t lock_guard(state_mutex);
 
 	switch (state) {
 	case state_tag::appending:
 		state = state_tag::writing;
 		write_impl(session, commit_coef, success_copies_num, limit_of_middle_chunk_attempts
-				, scale_retry_timeout);
+				, scale_retry_timeout, std::move(next));
 		break;
 	case state_tag::interrupted:
 		buffers.clear();
 		result = writer->get_result();
 		writer.reset();
 		lock_guard.unlock();
-		on_finished(buffered_writer_errc::interrupted);
+		next(buffered_writer_errc::interrupted);
 		break;
 	case state_tag::writing:
 	case state_tag::interrupting:
@@ -225,29 +224,30 @@ elliptics::buffered_writer_t::append_impl(const char *data, size_t size) {
 void
 elliptics::buffered_writer_t::write_impl(const ioremap::elliptics::session &session
 		, size_t commit_coef, size_t success_copies_num, size_t limit_of_middle_chunk_attempts
-		, double scale_retry_timeout) {
-	auto self = shared_from_this();
-	auto callback = [this, self] (const std::error_code &error_code) {
-		on_chunk_wrote(error_code);
-	};
-
+		, double scale_retry_timeout, callback_t next) {
 	writer = std::make_shared<writer_t>(
 			ioremap::swarm::logger(logger(), blackhole::log::attributes_t()), session, get_key()
-			, total_size, 0, commit_coef, success_copies_num, callback
+			, total_size, 0, commit_coef, success_copies_num
 			, limit_of_middle_chunk_attempts, scale_retry_timeout);
 
-	write_chunk();
+	write_chunk(std::move(next));
 }
 
 void
-elliptics::buffered_writer_t::write_chunk() {
+elliptics::buffered_writer_t::write_chunk(callback_t next) {
 	auto buffer = std::move(buffers.front());
 	buffers.pop_front();
-	writer->write(buffer.data(), buffer.size());
+
+	auto self = shared_from_this();
+	auto next_ = [this, self, next] (const std::error_code &error_code) {
+		on_chunk_wrote(error_code, std::move(next));
+	};
+
+	writer->write(buffer.data(), buffer.size(), std::move(next_));
 }
 
 void
-elliptics::buffered_writer_t::on_chunk_wrote(const std::error_code &error_code) {
+elliptics::buffered_writer_t::on_chunk_wrote(const std::error_code &error_code, callback_t next) {
 	lock_guard_t lock_guard(state_mutex);
 
 	switch (state) {
@@ -257,7 +257,7 @@ elliptics::buffered_writer_t::on_chunk_wrote(const std::error_code &error_code) 
 			result = writer->get_result();
 			writer.reset();
 			lock_guard.unlock();
-			on_finished(error_code);
+			next(error_code);
 			break;
 		}
 
@@ -266,11 +266,11 @@ elliptics::buffered_writer_t::on_chunk_wrote(const std::error_code &error_code) 
 			result = writer->get_result();
 			writer.reset();
 			lock_guard.unlock();
-			on_finished(buffered_writer_errc::success);
+			next(buffered_writer_errc::success);
 			break;
 		}
 
-		write_chunk();
+		write_chunk(std::move(next));
 		break;
 	case state_tag::interrupting:
 		state = state_tag::interrupted;
@@ -278,7 +278,7 @@ elliptics::buffered_writer_t::on_chunk_wrote(const std::error_code &error_code) 
 		result = writer->get_result();
 		writer.reset();
 		lock_guard.unlock();
-		on_finished(buffered_writer_errc::interrupted);
+		next(buffered_writer_errc::interrupted);
 		break;
 	case state_tag::appending:
 	case state_tag::completed:

--- a/src/buffered_writer.hpp
+++ b/src/buffered_writer.hpp
@@ -53,8 +53,7 @@ public:
 	typedef std::function<void (const std::error_code &)> callback_t;
 	typedef std::shared_ptr<writer_t> writer_ptr_t;
 
-	buffered_writer_t(ioremap::swarm::logger bh_logger_, std::string key_, size_t chunk_size_
-			, callback_t on_finished_);
+	buffered_writer_t(ioremap::swarm::logger bh_logger_, std::string key_, size_t chunk_size_);
 
 	void
 	append(const char *data, size_t size);
@@ -62,7 +61,7 @@ public:
 	void
 	write(const ioremap::elliptics::session &session, size_t commit_coef
 			, size_t success_copies_num, size_t limit_of_middle_chunk_attempts
-			, double scale_retry_timeout);
+			, double scale_retry_timeout, callback_t next);
 
 	void
 	interrupt();
@@ -111,13 +110,13 @@ private:
 	void
 	write_impl(const ioremap::elliptics::session &session, size_t commit_coef
 			, size_t success_copies_num, size_t limit_of_middle_chunk_attempts
-			, double scale_retry_timeout);
+			, double scale_retry_timeout, callback_t next);
 
 	void
-	write_chunk();
+	write_chunk(callback_t next);
 
 	void
-	on_chunk_wrote(const std::error_code &error_code);
+	on_chunk_wrote(const std::error_code &error_code, callback_t next);
 
 	state_tag state;
 	mutable mutex_t state_mutex;
@@ -126,8 +125,6 @@ private:
 
 	std::string key;
 	size_t chunk_size;
-
-	callback_t on_finished;
 
 	std::list<buffer_t> buffers;
 

--- a/src/writer.hpp
+++ b/src/writer.hpp
@@ -82,14 +82,14 @@ public:
 	writer_t(ioremap::swarm::logger bh_logger_
 			, const ioremap::elliptics::session &session_, std::string key_
 			, size_t total_size_, size_t offset_, size_t commit_coef_, size_t success_copies_num_
-			, callback_t on_complete_, size_t limit_of_attempts_ = 1, double scale_retry_timeout_ = 1
+			, size_t limit_of_attempts_ = 1, double scale_retry_timeout_ = 1
 			);
 
 	void
-	write(const char *data, size_t size);
+	write(const char *data, size_t size, callback_t next);
 
 	void
-	write(const ioremap::elliptics::data_pointer &data_pointer);
+	write(const ioremap::elliptics::data_pointer &data_pointer, callback_t next);
 
 	result_t
 	get_result() const;
@@ -150,7 +150,8 @@ private:
 
 	void
 	on_data_wrote(const ioremap::elliptics::sync_write_result &entries
-			, const ioremap::elliptics::error_info &error_info);
+			, const ioremap::elliptics::error_info &error_info
+			, callback_t next);
 
 	state_tag state;
 	mutable mutex_t state_mutex;
@@ -165,8 +166,6 @@ private:
 	size_t offset;
 	size_t commit_coef;
 	size_t success_copies_num;
-
-	callback_t on_complete;
 
 	size_t limit_of_attempts;
 	double scale_retry_timeout;


### PR DESCRIPTION
Writer and buffered writer does not take callbacks in constructors to
avoid permanent cyclic references.

Reviewers: @shindo 