### PR TITLE
MDS-1031: Read and lookup are processed with NOLOCK

### DIFF
--- a/src/download_info.cpp
+++ b/src/download_info.cpp
@@ -52,6 +52,10 @@ elliptics::download_info_t::on_request(const ioremap::thevoid::http_request &req
 		// in this moment. Hence session can be safely used without any check.
 		std::tie(session, key) = prepare_session(req.url().path(), ns_state);
 
+		if (proxy_settings(ns_state).check_for_update) {
+			session->set_cflags(session->get_cflags() | DNET_FLAGS_NOLOCK);
+		}
+
 		{
 			const auto &headers = req.headers();
 			if (const auto &xrh = headers.get("X-Regional-Host")) {

--- a/src/get.cpp
+++ b/src/get.cpp
@@ -531,6 +531,11 @@ req_get::on_request(const ioremap::thevoid::http_request &http_request
 		m_session->set_trace_bit(http_request.trace_bit());
 		m_session->set_trace_id(http_request.request_id());
 		m_session->set_timeout(server()->timeout.read);
+
+		if (proxy_settings(ns_state).check_for_update) {
+			m_session->set_cflags(m_session->get_cflags() | DNET_FLAGS_NOLOCK);
+		}
+
 		key = std::get<1>(prep_session).remote();
 	} catch (const std::exception &ex) {
 		MDS_LOG_ERROR("Get: \"%s\"", ex.what());

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -141,6 +141,8 @@ ioremap::elliptics::node proxy::generate_node(const rapidjson::Value &config, in
 		const auto &ell_threads = config["elliptics-threads"];
 		if (ell_threads.HasMember("io-thread-num"))
 			dnet_conf.io_thread_num = ell_threads["io-thread-num"].GetInt();
+		if (ell_threads.HasMember("nonblocking-io-thread-num"))
+			dnet_conf.nonblocking_io_thread_num = ell_threads["nonblocking-io-thread-num"].GetInt();
 		if (ell_threads.HasMember("net-thread-num"))
 			dnet_conf.net_thread_num = ell_threads["net-thread-num"].GetInt();;
 	}

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -500,6 +500,7 @@ elliptics::can_be_written(shared_logger_t shared_logger
 	}
 
 	session = session.clone();
+	session.set_cflags(session.get_cflags() | DNET_FLAGS_NOLOCK);
 	session.set_filter(ioremap::elliptics::filters::all);
 
 	auto future = session.parallel_lookup(key);


### PR DESCRIPTION
If namespace's option check_for_update is false then proxy will lookup and read data having set elliptics's cflag DNET_FLAGS_NOLOCK.

Also dnet option nonblocking_io_thread_num is now configurable.

Reviewers: @shindo 