### PR TITLE
handystats: use printf-like syntax for metrics' names.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,12 +22,12 @@ Build-Depends: debhelper (>=5),
  libcrypto++-dev,
  libyandex-utils-http,
  libcurl4-openssl-dev,
- handystats (>= 1.10.2), handystats (<< 1.11),
+ handystats (>= 1.11),
  libssl-dev,
 Standards-Version: 3.9.1
 
 Package: mediastorage-proxy
 Architecture: any
-Depends: ${shlibs:Depends}, libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, handystats (>= 1.10.2), handystats (<< 1.11), ubic,
+Depends: ${shlibs:Depends}, libyandex-ubic-shared-perl, libfcgi-procmanager-perl, libfcgi-perl, libfcgi-client-perl, libbsd-resource-perl, liblwp-protocol-http-socketunixalt-perl, handystats (>= 1.11), ubic,
 Description: Proxy with elliptics support based on thevoid
 

--- a/example/config_stats.json
+++ b/example/config_stats.json
@@ -47,30 +47,25 @@
 			"group-info-update-period" : 10
 		},
 		"handystats": {
-			"core": {
-				"enable": true
-			},
-			"metrics-dump": {
-				"interval": 500
-			},
-			"statistics": {
-				"histogram-bins": 30,
+			"enable": true,
+			"dump-interval": 500,
+			"defaults": {
 				"moving-interval": 60000,
-				"tags": []
+				"tags": [],
+				"rate-unit": "s"
 			},
-			"metrics": {
-				"gauge": {
-				},
-				"counter": {
-					"tags": ["rate"],
-					"rate-unit": "s"
-				},
-				"timer": {
-					"idle-timeout": 30000,
-					"tags": ["moving-avg", "quantile"]
-				}
+			"mds.{get,upload}": {
+				"tags": ["value", "rate"]
+			},
+			"mds.{get,upload}.reply.[1-5]{xx,[0-9][0-9]}": {
+				"tags": ["value", "rate"]
+			},
+			"mds.{get,upload}{,.reply}.time": {
+				"histogram-bins": 30,
+				"idle-timeout": 30000,
+				"tags": ["moving-avg", "quantile"]
 			}
-		}
+		},
 		"die-limit" : 1,
 		"eblob-style-path" : true,
 		"direction-bit-num" : 16,

--- a/src/handystats.hpp
+++ b/src/handystats.hpp
@@ -24,14 +24,6 @@
 #include <string>
 
 #include <handystats/measuring_points.hpp>
-#include <handystats/module.h>
-
-#ifndef _HAVE_HANDY_MODULE_MDS
-	#define _HAVE_HANDY_MODULE_MDS 1
-#endif
-
-HANDY_MODULE(MDS)
-
 
 // mds.REQUEST (counter)
 //    - total number of requests
@@ -52,54 +44,36 @@ namespace elliptics {
 // REQUEST
 
 inline void MDS_REQUEST_START(const std::string& method, const uint64_t& instance_id) {
-	char metric_name[256];
+	HANDY_COUNTER_INCREMENT(("mds.%s", method.c_str()));
 
-	sprintf(metric_name, "mds.%s", method.c_str());
-	MDS_COUNTER_INCREMENT(metric_name);
+	HANDY_TIMER_START(("mds.%s.time", method.c_str()), instance_id);
 
-	sprintf(metric_name, "mds.%s.time", method.c_str());
-	MDS_TIMER_START(metric_name, instance_id);
-
-	sprintf(metric_name, "mds.%s.reply.time", method.c_str());
-	MDS_TIMER_START(metric_name, instance_id);
+	HANDY_TIMER_START(("mds.%s.reply.time", method.c_str()), instance_id);
 }
 
 inline void MDS_REQUEST_STOP(const std::string& method, const uint64_t& instance_id) {
-	char metric_name[256];
-
-	sprintf(metric_name, "mds.%s.time", method.c_str());
-	MDS_TIMER_STOP(metric_name, instance_id);
+	HANDY_TIMER_STOP(("mds.%s.time", method.c_str()), instance_id);
 }
 
 inline void MDS_REQUEST_DISCARD(const std::string& method, const uint64_t& instance_id) {
-	char metric_name[256];
-
-	sprintf(metric_name, "mds.%s.time", method.c_str());
-	MDS_TIMER_DISCARD(metric_name, instance_id);
+	HANDY_TIMER_DISCARD(("mds.%s.time", method.c_str()), instance_id);
 }
 
 
 // REPLY
 
 inline void MDS_REQUEST_REPLY(const std::string& method, const int& code, const uint64_t& instance_id) {
-	char metric_name[256];
+	HANDY_COUNTER_INCREMENT(("mds.%s.reply.%d", method.c_str(), code));
 
-	sprintf(metric_name, "mds.%s.reply.%d", method.c_str(), code);
-	MDS_COUNTER_INCREMENT(metric_name);
-
-	sprintf(metric_name, "mds.%s.reply.%dxx", method.c_str(), code / 100);
-	MDS_COUNTER_INCREMENT(metric_name);
+	HANDY_COUNTER_INCREMENT(("mds.%s.reply.%dxx", method.c_str(), code / 100));
 
 	if (code / 100 != 2) {
-		sprintf(metric_name, "mds.%s.time", method.c_str());
-		MDS_TIMER_DISCARD(metric_name, instance_id);
+		HANDY_TIMER_DISCARD(("mds.%s.time", method.c_str()), instance_id);
 
-		sprintf(metric_name, "mds.%s.reply.time", method.c_str());
-		MDS_TIMER_DISCARD(metric_name, instance_id);
+		HANDY_TIMER_DISCARD(("mds.%s.reply.time", method.c_str()), instance_id);
 	}
 	else {
-		sprintf(metric_name, "mds.%s.reply.time", method.c_str());
-		MDS_TIMER_STOP(metric_name, instance_id);
+		HANDY_TIMER_STOP(("mds.%s.reply.time", method.c_str()), instance_id);
 	}
 }
 

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -408,10 +408,9 @@ bool proxy::initialize(const rapidjson::Value &config) {
 		if (config.HasMember("handystats")) {
 			HANDY_CONFIG_JSON(config["handystats"]);
 
-			if (config["handystats"].HasMember("core") &&
-					config["handystats"]["core"].HasMember("enable") &&
-					config["handystats"]["core"]["enable"].IsBool() &&
-					config["handystats"]["core"]["enable"].GetBool()
+			if (config["handystats"].HasMember("enable") &&
+					config["handystats"]["enable"].IsBool() &&
+					config["handystats"]["enable"].GetBool()
 				)
 			{
 				HANDY_INIT();


### PR DESCRIPTION
Dependency on handystats updated to >= 1.11, as printf-like syntax was introduced in this version.

Also, HANDY_MODULE was removed as it's not supported anymore.