### PR TITLE
Refactor namespace's settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCE
 	${PROJECT_SOURCE_DIR}/src/cdn_cache.cpp
 	${PROJECT_SOURCE_DIR}/src/utils.cpp
 	${PROJECT_SOURCE_DIR}/src/loggers.cpp
+	${PROJECT_SOURCE_DIR}/src/ns_settings.cpp
 	)
 
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/include)

--- a/src/delete.cpp
+++ b/src/delete.cpp
@@ -46,7 +46,7 @@ void req_delete::on_request(const ioremap::thevoid::http_request &req, const boo
 		}
 
 		if (!server()->check_basic_auth(ns_state.name()
-					, proxy_settings(ns_state).auth_key_for_write
+					, ns_settings(ns_state).auth_key_for_write
 					, req.headers().get("Authorization"))) {
 			auto token = server()->get_auth_token(req.headers().get("Authorization"));
 			MDS_LOG_INFO("%s: invalid token \"%s\"", url_str.c_str()
@@ -69,7 +69,7 @@ void req_delete::on_request(const ioremap::thevoid::http_request &req, const boo
 		session->set_timeout(server()->timeout.lookup);
 		session->set_filter(ioremap::elliptics::filters::positive);
 
-		if (proxy_settings(ns_state).check_for_update) {
+		if (ns_settings(ns_state).check_for_update) {
 			session->set_cflags(session->get_cflags() | DNET_FLAGS_NOLOCK);
 		}
 

--- a/src/download_info.cpp
+++ b/src/download_info.cpp
@@ -54,7 +54,7 @@ elliptics::download_info_t::on_request(const ioremap::thevoid::http_request &req
 		// in this moment. Hence session can be safely used without any check.
 		std::tie(session, key) = prepare_session(ns_state);
 
-		if (proxy_settings(ns_state).check_for_update) {
+		if (ns_settings(ns_state).check_for_update) {
 			session->set_cflags(session->get_cflags() | DNET_FLAGS_NOLOCK);
 		}
 
@@ -137,7 +137,7 @@ elliptics::download_info_t::get_namespace_state(const std::string &path
 
 void
 elliptics::download_info_t::check_signature() {
-	if (proxy_settings(ns_state).sign_token.empty()) {
+	if (ns_settings(ns_state).sign_token.empty()) {
 		throw http_error(403, "cannot generate downloadinfo xml without signature-token");
 	}
 }
@@ -155,7 +155,7 @@ elliptics::download_info_t::check_query_args() {
 	}
 
 	if (query.has_item("expiration-time")) {
-		if (!proxy_settings(ns_state).custom_expiration_time) {
+		if (!ns_settings(ns_state).custom_expiration_time) {
 			throw http_error(403, "using of expiration-time is prohibited");
 		}
 

--- a/src/get.cpp
+++ b/src/get.cpp
@@ -562,7 +562,7 @@ req_get::on_request(const ioremap::thevoid::http_request &http_request
 		m_session->set_trace_id(http_request.request_id());
 		m_session->set_timeout(server()->timeout.read);
 
-		if (proxy_settings(ns_state).check_for_update) {
+		if (ns_settings(ns_state).check_for_update) {
 			m_session->set_cflags(m_session->get_cflags() | DNET_FLAGS_NOLOCK);
 		}
 
@@ -588,7 +588,7 @@ req_get::on_request(const ioremap::thevoid::http_request &http_request
 	}
 
 	if (request().url().query().has_item("expiration-time")) {
-		if (!proxy_settings(ns_state).custom_expiration_time) {
+		if (!ns_settings(ns_state).custom_expiration_time) {
 			MDS_LOG_ERROR("using of expiration-time is prohibited");
 			send_reply(403);
 			MDS_REQUEST_REPLY("get", 403, reinterpret_cast<uint64_t>(this->reply().get()));
@@ -608,7 +608,7 @@ req_get::on_request(const ioremap::thevoid::http_request &http_request
 		}
 	}
 
-	if (!server()->check_basic_auth(ns_state.name(), proxy_settings(ns_state).auth_key_for_read
+	if (!server()->check_basic_auth(ns_state.name(), ns_settings(ns_state).auth_key_for_read
 				, http_request.headers().get("Authorization"))) {
 		auto token = server()->get_auth_token(http_request.headers().get("Authorization"));
 		MDS_LOG_INFO("invalid token \"%s\"", token.empty() ? "<none>" : token.c_str());
@@ -859,7 +859,7 @@ bool req_get::try_to_redirect_request(const ie::sync_lookup_result &slr, const s
 	auto redirect_arg = get_redirect_arg();
 
 	if (redirect_arg != redirect_arg_tag::client_want_redirect) {
-		auto redirect_size = proxy_settings(ns_state).redirect_content_length_threshold;
+		auto redirect_size = ns_settings(ns_state).redirect_content_length_threshold;
 		if (redirect_size == -1) {
 			MDS_LOG_INFO("cannot redirect: redirect-content-length-threshold is infinity");
 			return false;
@@ -879,7 +879,7 @@ bool req_get::try_to_redirect_request(const ie::sync_lookup_result &slr, const s
 	const auto &headers = request().headers();
 
 	try {
-		if (proxy_settings(ns_state).sign_token.empty()) {
+		if (ns_settings(ns_state).sign_token.empty()) {
 			MDS_LOG_INFO("cannot redirect without signature-token");
 
 			if (redirect_arg == redirect_arg_tag::client_want_redirect) {

--- a/src/ns_settings.cpp
+++ b/src/ns_settings.cpp
@@ -19,8 +19,8 @@
 
 #include "ns_settings.hpp"
 
-const elliptics::settings_t &
-elliptics::proxy_settings(const mastermind::namespace_state_t &ns_state) {
-	return static_cast<const settings_t &>(ns_state.settings().user_settings());
+const elliptics::ns_settings_t &
+elliptics::ns_settings(const mastermind::namespace_state_t &ns_state) {
+	return static_cast<const ns_settings_t &>(ns_state.settings().user_settings());
 }
 

--- a/src/ns_settings.cpp
+++ b/src/ns_settings.cpp
@@ -1,0 +1,26 @@
+/*
+	Mediastorage-proxy is a HTTP proxy for mediastorage based on elliptics
+	Copyright (C) 2013-2015 Yandex
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#include "ns_settings.hpp"
+
+const elliptics::settings_t &
+elliptics::proxy_settings(const mastermind::namespace_state_t &ns_state) {
+	return static_cast<const settings_t &>(ns_state.settings().user_settings());
+}
+

--- a/src/ns_settings.hpp
+++ b/src/ns_settings.hpp
@@ -30,10 +30,10 @@
 
 namespace elliptics {
 
-struct settings_t
+struct ns_settings_t
 	: public mastermind::namespace_state_t::user_settings_t {
 
-	settings_t()
+	ns_settings_t()
 		: redirect_content_length_threshold(-1)
 		, can_choose_couple_to_upload(false)
 		, multipart_content_length_threshold(0)
@@ -66,8 +66,8 @@ struct settings_t
 	bool check_for_update;
 };
 
-const settings_t &
-proxy_settings(const mastermind::namespace_state_t &ns_state);
+const ns_settings_t &
+ns_settings(const mastermind::namespace_state_t &ns_state);
 
 } // namespace elliptics
 

--- a/src/ns_settings.hpp
+++ b/src/ns_settings.hpp
@@ -1,0 +1,75 @@
+/*
+	Mediastorage-proxy is a HTTP proxy for mediastorage based on elliptics
+	Copyright (C) 2013-2015 Yandex
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+#ifndef MDS_PROXY__SRC__NS_SETTINGS__HPP
+#define MDS_PROXY__SRC__NS_SETTINGS__HPP
+
+#include <elliptics/session.hpp>
+
+#include <libmastermind/mastermind.hpp>
+
+#include <vector>
+#include <string>
+#include <chrono>
+
+namespace elliptics {
+
+struct settings_t
+	: public mastermind::namespace_state_t::user_settings_t {
+
+	settings_t()
+		: redirect_content_length_threshold(-1)
+		, can_choose_couple_to_upload(false)
+		, multipart_content_length_threshold(0)
+		, custom_expiration_time(false)
+		, success_copies_num(-1)
+		, check_for_update(true)
+	{}
+
+	std::string name;
+	ioremap::elliptics::result_checker result_checker;
+
+	std::string auth_key_for_write;
+	std::string auth_key_for_read;
+
+	std::vector<int> static_couple;
+
+	std::string sign_token;
+	std::string sign_path_prefix;
+	std::string sign_port;
+
+	std::chrono::seconds redirect_expire_time;
+	int64_t redirect_content_length_threshold;
+
+	bool can_choose_couple_to_upload;
+	int64_t multipart_content_length_threshold;
+	bool custom_expiration_time;
+
+	int success_copies_num;
+
+	bool check_for_update;
+};
+
+const settings_t &
+proxy_settings(const mastermind::namespace_state_t &ns_state);
+
+} // namespace elliptics
+
+#endif /* MDS_PROXY__SRC__NS_SETTINGS__HPP */
+

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -130,11 +130,6 @@ std::string id_str(const ioremap::elliptics::key &key, ioremap::elliptics::sessi
 	return std::string(str);
 }
 
-const settings_t &
-proxy_settings(const mastermind::namespace_state_t &ns_state) {
-	return static_cast<const settings_t &>(ns_state.settings().user_settings());
-}
-
 ioremap::elliptics::node proxy::generate_node(const rapidjson::Value &config, int &timeout_def) {
 	struct dnet_config dnet_conf;
 	memset(&dnet_conf, 0, sizeof(dnet_conf));

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -806,8 +806,8 @@ int proxy::die_limit() const {
 }
 
 std::vector<int> proxy::groups_for_upload(const mastermind::namespace_state_t &ns_state, uint64_t size) {
-	if (!proxy_settings(ns_state).static_couple.empty())
-		return proxy_settings(ns_state).static_couple;
+	if (!ns_settings(ns_state).static_couple.empty())
+		return ns_settings(ns_state).static_couple;
 	return ns_state.weights().groups(size);
 }
 
@@ -825,7 +825,7 @@ proxy::prepare_session(const std::string &url, const mastermind::namespace_state
 	std::string filename;
 
 	if (session) {
-		if (proxy_settings(ns_state).static_couple.empty()) {
+		if (ns_settings(ns_state).static_couple.empty()) {
 			auto bg = url.find('/', 1) + 1;
 			auto eg = url.find('/', bg);
 			auto bf = eg + 1;
@@ -848,7 +848,7 @@ proxy::prepare_session(const std::string &url, const mastermind::namespace_state
 			auto bf = url.find('/', 1) + 1;
 			auto ef = url.find('?', bf);
 			url.substr(bf, ef - bf).swap(filename);
-			groups = proxy_settings(ns_state).static_couple;
+			groups = ns_settings(ns_state).static_couple;
 		}
 
 		session->set_groups(groups);
@@ -928,7 +928,7 @@ proxy::generate_signature_for_elliptics_file(const ioremap::elliptics::sync_look
 	, boost::optional<std::chrono::seconds> optional_expiration_time) {
 
 	bool use_regional_host = !x_regional_host.empty() && cdn_cache->check_host(x_regional_host);
-	if (proxy_settings(ns_state).sign_token.empty()) {
+	if (ns_settings(ns_state).sign_token.empty()) {
 		throw std::runtime_error(
 				"cannot generate signature for elliptics file without signature-token");
 	}
@@ -941,7 +941,7 @@ proxy::generate_signature_for_elliptics_file(const ioremap::elliptics::sync_look
 			continue;
 		}
 
-		lookup_result entry(*it, proxy_settings(ns_state).sign_port);
+		lookup_result entry(*it, ns_settings(ns_state).sign_port);
 
 		std::string host;
 		std::string path = entry.path();
@@ -950,7 +950,7 @@ proxy::generate_signature_for_elliptics_file(const ioremap::elliptics::sync_look
 
 		{
 			{
-				const auto &path_prefix = proxy_settings(ns_state).sign_path_prefix;
+				const auto &path_prefix = ns_settings(ns_state).sign_path_prefix;
 				if (strncmp(path.c_str(), path_prefix.c_str(), path_prefix.size())) {
 					std::ostringstream oss;
 					oss
@@ -973,7 +973,7 @@ proxy::generate_signature_for_elliptics_file(const ioremap::elliptics::sync_look
 
 				auto now = system_clock::now().time_since_epoch();
 				auto expiration_time = optional_expiration_time.get_value_or(
-						proxy_settings(ns_state).redirect_expire_time);
+						ns_settings(ns_state).redirect_expire_time);
 
 				std::ostringstream ts_oss;
 				ts_oss
@@ -985,7 +985,7 @@ proxy::generate_signature_for_elliptics_file(const ioremap::elliptics::sync_look
 			{
 				std::ostringstream oss;
 				oss << host << path << '/' << ts;
-				sign = hmac(oss.str(), proxy_settings(ns_state).sign_token);
+				sign = hmac(oss.str(), ns_settings(ns_state).sign_token);
 			}
 		}
 
@@ -1042,7 +1042,7 @@ void proxy::cache_update_callback() {
 
 mastermind::namespace_state_t::user_settings_ptr_t
 proxy::settings_factory(const std::string &name, const kora::config_t &config) {
-	std::unique_ptr<settings_t> settings(new settings_t);
+	std::unique_ptr<ns_settings_t> settings(new ns_settings_t);
 
 	settings->name = name;
 

--- a/src/proxy.hpp
+++ b/src/proxy.hpp
@@ -25,6 +25,7 @@
 #include "magic_provider.hpp"
 #include "utils.hpp"
 #include "cdn_cache.hpp"
+#include "ns_settings.hpp"
 
 #include <elliptics/session.hpp>
 #include <libmastermind/mastermind.hpp>
@@ -61,45 +62,6 @@ T get_arg(const ioremap::swarm::url_query &query_list, const std::string &name, 
 }
 
 std::string id_str(const ioremap::elliptics::key &key, ioremap::elliptics::session sess);
-
-struct settings_t
-	: public mastermind::namespace_state_t::user_settings_t {
-
-	settings_t()
-		: redirect_content_length_threshold(-1)
-		, can_choose_couple_to_upload(false)
-		, multipart_content_length_threshold(0)
-		, custom_expiration_time(false)
-		, success_copies_num(-1)
-		, check_for_update(true)
-	{}
-
-	std::string name;
-	ioremap::elliptics::result_checker result_checker;
-
-	std::string auth_key_for_write;
-	std::string auth_key_for_read;
-
-	std::vector<int> static_couple;
-
-	std::string sign_token;
-	std::string sign_path_prefix;
-	std::string sign_port;
-
-	std::chrono::seconds redirect_expire_time;
-	int64_t redirect_content_length_threshold;
-
-	bool can_choose_couple_to_upload;
-	int64_t multipart_content_length_threshold;
-	bool custom_expiration_time;
-
-	int success_copies_num;
-
-	bool check_for_update;
-};
-
-const settings_t &
-proxy_settings(const mastermind::namespace_state_t &ns_state);
 
 class proxy : public ioremap::thevoid::server<proxy>
 {

--- a/src/upload.cpp
+++ b/src/upload.cpp
@@ -99,7 +99,7 @@ upload_t::on_headers(ioremap::thevoid::http_request &&http_request) {
 
 	{
 		if (!server()->check_basic_auth(ns_state.name()
-					, proxy_settings(ns_state).auth_key_for_write
+					, ns_settings(ns_state).auth_key_for_write
 					, http_request.headers().get("Authorization"))) {
 			auto token = server()->get_auth_token(http_request.headers().get("Authorization"));
 			MDS_LOG_INFO("invalid token \"%s\"", token.empty() ? "<none>" : token.c_str());
@@ -128,7 +128,7 @@ upload_t::on_headers(ioremap::thevoid::http_request &&http_request) {
 				, "multipart/form-data;");
 
 		if (!res) {
-			auto size = proxy_settings(ns_state).multipart_content_length_threshold;
+			auto size = ns_settings(ns_state).multipart_content_length_threshold;
 
 			if (size != -1 && static_cast<size_t>(size) < total_size) {
 				MDS_LOG_INFO(
@@ -169,7 +169,7 @@ boost::optional<elliptics::couple_iterator_t>
 elliptics::upload_t::create_couple_iterator(const ioremap::thevoid::http_request &http_request
 		, const mastermind::namespace_state_t &ns_state, size_t total_size) {
 	if (auto arg = http_request.url().query().item_value("couple_id")) {
-		if (!proxy_settings(ns_state).can_choose_couple_to_upload) {
+		if (!ns_settings(ns_state).can_choose_couple_to_upload) {
 			MDS_LOG_INFO("client wants to choose couple by himself, but you forbade that");
 			reply()->send_error(ioremap::swarm::http_response::forbidden);
 			return boost::none;
@@ -217,8 +217,8 @@ elliptics::upload_t::create_couple_iterator(const ioremap::thevoid::http_request
 		return couple_iterator_t(couple);
 	} else {
 		try {
-			if (!proxy_settings(ns_state).static_couple.empty()) {
-				return couple_iterator_t(proxy_settings(ns_state).static_couple);
+			if (!ns_settings(ns_state).static_couple.empty()) {
+				return couple_iterator_t(ns_settings(ns_state).static_couple);
 			}
 
 			return couple_iterator_t(ns_state.weights().couple_sequence(total_size));

--- a/src/upload_multipart.cpp
+++ b/src/upload_multipart.cpp
@@ -359,7 +359,7 @@ upload_multipart_t::start_writing() {
 	// Hence write_session can be safely used without any check
 	buffered_writer->write(*server()->write_session(http_request, couple)
 			, server()->timeout_coef.data_flow_rate
-			, proxy_settings(ns_state).success_copies_num
+			, ns_settings(ns_state).success_copies_num
 			, server()->limit_of_middle_chunk_attempts
 			, server()->scale_retry_timeout
 			, std::move(next));
@@ -488,7 +488,7 @@ upload_multipart_t::send_result() {
 			<< "\" size=\"" << it->second.total_size
 			<< "\" key=\"";
 
-		if (proxy_settings(ns_state).static_couple.empty()) {
+		if (ns_settings(ns_state).static_couple.empty()) {
 			oss << couple_id << '/';
 		}
 

--- a/src/upload_simple.cpp
+++ b/src/upload_simple.cpp
@@ -126,7 +126,7 @@ upload_simple_t::send_result() {
 		<< "\" size=\"" << result.total_size
 		<< "\" key=\"";
 
-	if (proxy_settings(ns_state).static_couple.empty()) {
+	if (ns_settings(ns_state).static_couple.empty()) {
 		oss << couple_info.id << '/';
 	}
 
@@ -243,7 +243,7 @@ elliptics::upload_simple_t::get_next_couple_info(
 			oss << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<post>\n";
 
 			oss << "<key>";
-			if (proxy_settings(ns_state).static_couple.empty()) {
+			if (ns_settings(ns_state).static_couple.empty()) {
 				oss << couple_info.id << '/';
 			}
 			oss << encode_for_xml(filename);
@@ -286,7 +286,7 @@ elliptics::upload_simple_t::make_writer(const groups_t &groups) {
 			copy_logger(logger())
 			, session, key
 			, *request().headers().content_length(), offset
-			, server()->timeout_coef.data_flow_rate , proxy_settings(ns_state).success_copies_num
+			, server()->timeout_coef.data_flow_rate , ns_settings(ns_state).success_copies_num
 			, server()->limit_of_middle_chunk_attempts
 			, server()->scale_retry_timeout
 			);

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -503,7 +503,7 @@ elliptics::can_be_written(shared_logger_t shared_logger
 		MDS_LOG_INFO("%s", msg.c_str());
 	}
 
-	if (!proxy_settings(ns_state).check_for_update) {
+	if (!ns_settings(ns_state).check_for_update) {
 		MDS_LOG_INFO("check for update is disabled for the namespace");
 		next(true);
 		return;


### PR DESCRIPTION
- Move class settings_t to ns_settings.hpp
- Move declaration of function proxy_setting to ns_settings.hpp
- Move implementation of proxy_settings to ns_settings.cpp
- Rename settings_t to ns_settings_t
- Rename proxy_settings to ns_settings