### PR TITLE
Add log for getting a couple by a group

### DIFF
--- a/src/proxy.hpp
+++ b/src/proxy.hpp
@@ -141,6 +141,9 @@ public:
 	std::tuple<std::string, mastermind::namespace_state_t>
 	get_file_info(const ioremap::thevoid::http_request &req);
 
+	std::vector<int>
+	get_groups(const mastermind::namespace_state_t &ns_state, int group);
+
 	std::tuple<boost::optional<ioremap::elliptics::session>, ioremap::elliptics::key>
 	prepare_session(const std::string &url, const mastermind::namespace_state_t &ns_state);
 


### PR DESCRIPTION
This log will allow us to monitor whether a group, that is used in a
request, is not a minimal group in the couple or whether the group does
not belong to any couple.