### PR TITLE
Add namespace option add-orig-path-query-arg

### DIFF
--- a/src/get.cpp
+++ b/src/get.cpp
@@ -859,6 +859,11 @@ std::vector<std::tuple<std::string, std::string>>
 req_get::get_redirect_query_args() {
 	std::vector<std::tuple<std::string, std::string>> result;
 
+	if (ns_settings(ns_state).add_orig_path_query_arg) {
+		result.emplace_back(std::make_tuple("orig_path"
+					, url_encode(request().url().path())));
+	}
+
 	const auto &query = request().url().query();
 	const auto &redirect_query_args = ns_settings(ns_state).redirect_query_args;
 

--- a/src/ns_settings.hpp
+++ b/src/ns_settings.hpp
@@ -35,6 +35,7 @@ struct ns_settings_t
 
 	ns_settings_t()
 		: redirect_content_length_threshold(-1)
+		, add_orig_path_query_arg(false)
 		, can_choose_couple_to_upload(false)
 		, multipart_content_length_threshold(0)
 		, custom_expiration_time(false)
@@ -57,6 +58,7 @@ struct ns_settings_t
 	std::chrono::seconds redirect_expire_time;
 	int64_t redirect_content_length_threshold;
 	std::vector<std::string> redirect_query_args;
+	bool add_orig_path_query_arg;
 
 	bool can_choose_couple_to_upload;
 	int64_t multipart_content_length_threshold;

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -1071,6 +1071,9 @@ proxy::settings_factory(const std::string &name, const kora::config_t &config) {
 						query_args_redirect_config.at<std::string>(index));
 			}
 		}
+
+		settings->add_orig_path_query_arg = redirect_config.at<bool>("add-orig-path-query-arg"
+				, false);
 	}
 
 	if (config.has("features")) {


### PR DESCRIPTION
If the option is set, a redirect location will contain query argument
'orig-path' with the original request path as a value.